### PR TITLE
⬆️ Support RxSwift 6.0.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 
 let package = Package(
     name: "InfiniteLayout",
-    platforms: [.iOS(.v8), .tvOS(.v9)],
+    platforms: [.iOS(.v9), .tvOS(.v9)],
     products: [
         .library(
             name: "InfiniteLayout",
@@ -15,8 +15,8 @@ let package = Package(
             targets: ["RxInfiniteLayout"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/ReactiveX/RxSwift.git", .upToNextMajor(from: "5.0.0")),
-        .package(url: "https://github.com/RxSwiftCommunity/RxDataSources.git", .upToNextMajor(from: "4.0.0")),
+        .package(url: "https://github.com/ReactiveX/RxSwift.git", .upToNextMajor(from: "6.0.0")),
+        .package(url: "https://github.com/RxSwiftCommunity/RxDataSources.git", .upToNextMajor(from: "5.0.0")),
     ],
     targets: [
         .target(

--- a/Sources/InfiniteLayout/InfiniteDataSource.swift
+++ b/Sources/InfiniteLayout/InfiniteDataSource.swift
@@ -8,15 +8,15 @@
 import UIKit
 
 open class InfiniteDataSources {
-    
+    public static var originCount: Int = 0
     public static func section(from infiniteSection: Int, numberOfSections: Int) -> Int {
         return infiniteSection % numberOfSections
     }
-    
+
     public static func indexPath(from infiniteIndexPath: IndexPath, numberOfSections: Int, numberOfItems: Int) -> IndexPath {
         return IndexPath(item: infiniteIndexPath.item % numberOfItems, section: self.section(from: infiniteIndexPath.section, numberOfSections: numberOfSections))
     }
-    
+
     public static func multiplier(estimatedItemSize: CGSize, enabled: Bool) -> Int {
         guard enabled else {
             return 1
@@ -25,12 +25,13 @@ open class InfiniteDataSources {
         let count = ceil(InfiniteLayout.minimumContentSize / min)
         return Int(count)
     }
-    
+
     public static func numberOfSections(numberOfSections: Int, multiplier: Int) -> Int {
         return numberOfSections > 1 ? numberOfSections * multiplier : numberOfSections
     }
     
     public static func numberOfItemsInSection(numberOfItemsInSection: Int, numberOfSections: Int, multiplier: Int) -> Int {
+        originCount = numberOfItemsInSection
         return numberOfSections > 1 ? numberOfItemsInSection : numberOfItemsInSection * multiplier
     }
 }


### PR DESCRIPTION
Updated to RxSwift 6.0.0 and RxDataSource 5.0.0 resulted in the function of modelCentered<T> and modelSelected<T> not working properly and the outOfBounds error being emitted. 

The syntax of try self.model(at: $0) was determined to have failed in modelCenter<T> and was modified.